### PR TITLE
Fix usage on HVM instances

### DIFF
--- a/grow.sh
+++ b/grow.sh
@@ -3,15 +3,15 @@ RESIZE_DEV="$1"
 test -b /dev/${RESIZE_DEV} || export RESIZE_DEV=""
 if [ "X${RESIZE_DEV}" = "X" ] ; then
    echo "Must set RESIZE_DEV=[a_valid_block_device]"
-   echo "docker run -it --rm slamper/disk_resizer xvda"
+   echo "docker run -it --rm slamper/resizefs xvda"
    echo "or"
-   echo "docker run -it --rm --privileged slamper/disk_resizer xvda1"
+   echo "docker run -it --rm --privileged slamper/resizefs xvda1"
    echo "or any other available valid block device"
    exit 1
 elif [ "${RESIZE_DEV}" = "xvda1" ] ; then
    resize2fs /dev/${RESIZE_DEV}
 else
-  growpart /dev/${RESIZE_DEV} 1
-  probepart
-  resize2fs /dev/${RESIZE_DEV}
+  /growpart /dev/${RESIZE_DEV} 1
+  partprobe 
+  resize2fs /dev/${RESIZE_DEV}1
 fi


### PR DESCRIPTION
  - typo in partprobe
  - absolute path for growpart
  - correctly specify 1st partition of RESIZE_DEV on HVM
  - tested on m1.medium pv, t2.micro hvm
  - build avail as guruvan/resizefs:v0.0.4
  - TODO requires testing on bare-metal machine (don't have any to test here) 